### PR TITLE
feat(@built-in-ai/core): multi modal support

### DIFF
--- a/.changeset/late-suits-sell.md
+++ b/.changeset/late-suits-sell.md
@@ -1,0 +1,5 @@
+---
+"@built-in-ai/core": minor
+---
+
+feat: add multimodal support

--- a/README.md
+++ b/README.md
@@ -64,23 +64,25 @@ for await (const chunk of result.textStream) {
 
 Look [here](/packages/built-in-ai/README.md) for more usage examples and API reference.
 
-## Supported Features
+## Features
 
 ### Supported
 
-- Text generation
-- Streaming responses
-- Temperature control
-- Response format constraints (JSON)
-- Abort signals
+- [x] **Text generation** (`generateText()`)
+- [x] **Streaming responses** (`streamText()`)
+- [x] **Multimodal functionality** (image and audio support)*
+- [x] **Temperature control**
+- [x] **Response format constraints** (JSON)
+- [x] **Abort signals**
 
-### Needs to be implemented (when implemented in the Prompt API)
+### Planned (when implemented in the Prompt API)
 
-- Tool calling
-- Multimodality (images)
-- Token counting
-- Custom stop sequences
-- Presence/frequency penalties
+- [ ] **Tool calling**
+- [ ] **Token counting**
+- [ ] **Custom stop sequences**
+- [ ] **Presence/frequency penalties**
+
+> *Multimodal functionality is currently only available in Chrome's Prompt API implementation
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Look [here](/packages/built-in-ai/README.md) for more usage examples and API ref
 
 - [x] **Text generation** (`generateText()`)
 - [x] **Streaming responses** (`streamText()`)
-- [x] **Multimodal functionality** (image and audio support)*
+- [x] **Multimodal functionality** (image and audio support)\*
 - [x] **Temperature control**
 - [x] **Response format constraints** (JSON)
 - [x] **Abort signals**
@@ -82,7 +82,7 @@ Look [here](/packages/built-in-ai/README.md) for more usage examples and API ref
 - [ ] **Custom stop sequences**
 - [ ] **Presence/frequency penalties**
 
-> *Multimodal functionality is currently only available in Chrome's Prompt API implementation
+> \*Multimodal functionality is currently only available in Chrome's Prompt API implementation
 
 ## Contributing
 

--- a/examples/next-hybrid/app/layout.tsx
+++ b/examples/next-hybrid/app/layout.tsx
@@ -16,7 +16,6 @@ export default function RootLayout({
   return (
     <>
       <html lang="en" suppressHydrationWarning>
-        <head />
         <body>
           <ThemeProvider
             attribute="class"

--- a/examples/next-hybrid/util/client-side-chat-transport.ts
+++ b/examples/next-hybrid/util/client-side-chat-transport.ts
@@ -17,39 +17,17 @@ export class ClientSideChatTransport implements ChatTransport<UIMessage> {
       abortSignal: AbortSignal | undefined;
     } & {
       trigger:
-      | "submit-user-message"
-      | "submit-tool-result"
-      | "regenerate-assistant-message";
+        | "submit-user-message"
+        | "submit-tool-result"
+        | "regenerate-assistant-message";
       messageId: string | undefined;
     } & ChatRequestOptions,
   ): Promise<ReadableStream<UIMessageChunk>> {
     const prompt = convertToModelMessages(options.messages);
 
-    // Load the npm-header.png image from the root directory
-    const imageResponse = await fetch('https://hips.hearstapps.com/hmg-prod/images/ginger-maine-coon-kitten-running-on-lawn-in-royalty-free-image-1719608142.jpg?crop=1xw:0.84415xh;0,0.185xh&resize=1200:*');
-    const imageBlob = await imageResponse.blob();
-    const imageArrayBuffer = await imageBlob.arrayBuffer();
-    const imageUint8Array = new Uint8Array(imageArrayBuffer);
-
-    // Create a test message with image and text to demonstrate multimodal capabilities
-    const testMessages = [
-      {
-        role: 'user' as const,
-        content: [
-          { type: 'text' as const, text: 'Please describe this image in detail.' },
-          {
-            type: 'file' as const,
-            mediaType: 'image/png',
-            data: imageUint8Array,
-          },
-        ],
-      },
-    ];
-
-    // Continue with the regular streaming for the actual chat
     const result = streamText({
       model: builtInAI(),
-      messages: testMessages,
+      messages: prompt,
       abortSignal: options.abortSignal,
     });
 

--- a/examples/next-hybrid/util/client-side-chat-transport.ts
+++ b/examples/next-hybrid/util/client-side-chat-transport.ts
@@ -3,6 +3,7 @@ import {
   UIMessage,
   UIMessageChunk,
   streamText,
+  generateText,
   convertToModelMessages,
   ChatRequestOptions,
 } from "ai";
@@ -16,17 +17,39 @@ export class ClientSideChatTransport implements ChatTransport<UIMessage> {
       abortSignal: AbortSignal | undefined;
     } & {
       trigger:
-        | "submit-user-message"
-        | "submit-tool-result"
-        | "regenerate-assistant-message";
+      | "submit-user-message"
+      | "submit-tool-result"
+      | "regenerate-assistant-message";
       messageId: string | undefined;
     } & ChatRequestOptions,
   ): Promise<ReadableStream<UIMessageChunk>> {
     const prompt = convertToModelMessages(options.messages);
 
+    // Load the npm-header.png image from the root directory
+    const imageResponse = await fetch('https://hips.hearstapps.com/hmg-prod/images/ginger-maine-coon-kitten-running-on-lawn-in-royalty-free-image-1719608142.jpg?crop=1xw:0.84415xh;0,0.185xh&resize=1200:*');
+    const imageBlob = await imageResponse.blob();
+    const imageArrayBuffer = await imageBlob.arrayBuffer();
+    const imageUint8Array = new Uint8Array(imageArrayBuffer);
+
+    // Create a test message with image and text to demonstrate multimodal capabilities
+    const testMessages = [
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text' as const, text: 'Please describe this image in detail.' },
+          {
+            type: 'file' as const,
+            mediaType: 'image/png',
+            data: imageUint8Array,
+          },
+        ],
+      },
+    ];
+
+    // Continue with the regular streaming for the actual chat
     const result = streamText({
       model: builtInAI(),
-      messages: prompt,
+      messages: testMessages,
       abortSignal: options.abortSignal,
     });
 

--- a/packages/built-in-ai/README.md
+++ b/packages/built-in-ai/README.md
@@ -38,11 +38,11 @@ The `@built-in-ai/core` package is the AI SDK provider for your Chrome and Edge 
 
 2. Enable these experimental flags:
    - If you're using Chrome:
-     1. Go to chrome://flags/#prompt-api-for-gemini-nano and set it to Enabled
-     2. Go to chrome://flags/#optimization-guide-on-device-model and set it to Enabled BypassPrefRequirement
-     3. Go to chrome://components and click Check for Update on Optimization Guide On Device Model
+     1. Go to `chrome://flags/`, search for 'Prompt API for Gemini Nano' and set it to Enabled
+     2. Go to `chrome://flags/#optimization-guide-on-device-model` and set it to Enabled BypassPrefRequirement
+     3. Go to `chrome://components` and click Check for Update on Optimization Guide On Device Model
    - If you're using Edge:
-     1. Go to edge://flags/#prompt-api-for-phi-mini and set it to Enabled
+     1. Go to `edge://flags/#prompt-api-for-phi-mini` and set it to Enabled
 
 For more information, check out [this guide](https://developer.chrome.com/docs/extensions/ai/prompt-api)
 
@@ -152,13 +152,43 @@ export default function Chat() {
 }
 ```
 
+## Multimodal
+
+The Prompt API also supports both passing images and audio files
+
+```tsx:useChat() multimodal example
+import { streamText } from "ai";
+import { builtInAI } from "@built-in-ai/core";
+
+const result = streamText({
+  model: builtInAI(),
+  messages: [
+    {
+      role: "user",
+      content: [{ type: "file", mediaType: "audio/mp3", data: audioData }],
+    },
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "What's in this image?" },
+        { type: "file", mediaType: "image/png", data: base64Data },
+      ],
+    },
+  ],
+});
+
+for await (const chunk of result.textStream) {
+  console.log(chunk);
+}
+```
+
 ## API Reference
 
 ### `builtInAI(modelId?, settings?)`
 
 Creates a browser AI model instance for chat or embeddings.
 
-**Chat Models:**
+**For Chat Models:**
 
 - `modelId` (optional): The model identifier, defaults to 'text'
 - `settings` (optional): Configuration options for the chat model

--- a/packages/built-in-ai/src/built-in-ai-language-model.ts
+++ b/packages/built-in-ai/src/built-in-ai-language-model.ts
@@ -56,7 +56,9 @@ function hasMultimodalContent(prompt: LanguageModelV2Prompt): boolean {
 /**
  * Get expected inputs based on prompt content
  */
-function getExpectedInputs(prompt: LanguageModelV2Prompt): Array<{ type: "text" | "image" | "audio" }> {
+function getExpectedInputs(
+  prompt: LanguageModelV2Prompt,
+): Array<{ type: "text" | "image" | "audio" }> {
   const inputs = new Set<"text" | "image" | "audio">();
   // Don't add text by default - it's assumed by the Prompt API
 
@@ -76,7 +78,7 @@ function getExpectedInputs(prompt: LanguageModelV2Prompt): Array<{ type: "text" 
     }
   }
 
-  return Array.from(inputs).map(type => ({ type }));
+  return Array.from(inputs).map((type) => ({ type }));
 }
 
 export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
@@ -107,7 +109,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
   private async getSession(
     options?: LanguageModelCreateOptions,
     expectedInputs?: Array<{ type: "text" | "image" | "audio" }>,
-    systemMessage?: string
+    systemMessage?: string,
   ): Promise<LanguageModel> {
     if (typeof LanguageModel === "undefined") {
       throw new LoadSettingError({
@@ -138,7 +140,9 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
 
     // Add system message to initialPrompts if provided
     if (systemMessage) {
-      mergedOptions.initialPrompts = [{ role: "system", content: systemMessage }];
+      mergedOptions.initialPrompts = [
+        { role: "system", content: systemMessage },
+      ];
     }
 
     // Add expected inputs if provided
@@ -250,7 +254,9 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings,
       promptOptions,
       hasMultiModalInput,
-      expectedInputs: hasMultiModalInput ? getExpectedInputs(prompt) : undefined
+      expectedInputs: hasMultiModalInput
+        ? getExpectedInputs(prompt)
+        : undefined,
     };
   }
 
@@ -263,9 +269,14 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
    */
   public async doGenerate(options: LanguageModelV2CallOptions) {
     const converted = this.getArgs(options);
-    const { systemMessage, messages, warnings, promptOptions, expectedInputs } = converted;
+    const { systemMessage, messages, warnings, promptOptions, expectedInputs } =
+      converted;
 
-    const session = await this.getSession(undefined, expectedInputs, systemMessage);
+    const session = await this.getSession(
+      undefined,
+      expectedInputs,
+      systemMessage,
+    );
 
     const text = await session.prompt(messages, promptOptions);
 
@@ -298,9 +309,20 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
    */
   public async doStream(options: LanguageModelV2CallOptions) {
     const converted = this.getArgs(options);
-    const { systemMessage, messages, warnings, promptOptions, expectedInputs, hasMultiModalInput } = converted;
+    const {
+      systemMessage,
+      messages,
+      warnings,
+      promptOptions,
+      expectedInputs,
+      hasMultiModalInput,
+    } = converted;
 
-    const session = await this.getSession(undefined, expectedInputs, systemMessage);
+    const session = await this.getSession(
+      undefined,
+      expectedInputs,
+      systemMessage,
+    );
 
     // Pass abort signal to the native streaming method
     const streamOptions = {
@@ -375,5 +397,3 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
     };
   }
 }
-
-

--- a/packages/built-in-ai/src/built-in-ai-language-model.ts
+++ b/packages/built-in-ai/src/built-in-ai-language-model.ts
@@ -15,8 +15,7 @@ export type BuiltInAIChatModelId = "text";
 
 export interface BuiltInAIChatSettings extends LanguageModelCreateOptions {
   /**
-   * Expected input types for the session. This helps the browser prepare
-   * for multimodal inputs and download necessary model components.
+   * Expected input types for the session, for multimodal inputs.
    */
   expectedInputs?: Array<{
     type: "text" | "image" | "audio";
@@ -59,7 +58,7 @@ function hasMultimodalContent(prompt: LanguageModelV2Prompt): boolean {
  */
 function getExpectedInputs(prompt: LanguageModelV2Prompt): Array<{ type: "text" | "image" | "audio" }> {
   const inputs = new Set<"text" | "image" | "audio">();
-  // Don't add text by default - it's assumed by the browser API
+  // Don't add text by default - it's assumed by the Prompt API
 
   for (const message of prompt) {
     if (message.role === "user") {
@@ -107,12 +106,13 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
 
   private async getSession(
     options?: LanguageModelCreateOptions,
-    expectedInputs?: Array<{ type: "text" | "image" | "audio" }>
+    expectedInputs?: Array<{ type: "text" | "image" | "audio" }>,
+    systemMessage?: string
   ): Promise<LanguageModel> {
     if (typeof LanguageModel === "undefined") {
       throw new LoadSettingError({
         message:
-          "Browser AI API is not available. This library requires Chrome or Edge browser with built-in AI capabilities.",
+          "Prompt API is not available. This library requires Chrome or Edge browser with built-in AI capabilities.",
       });
     }
 
@@ -136,28 +136,17 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       ...options,
     };
 
-    // Try to create multimodal session if expected inputs are provided
-    if (expectedInputs && expectedInputs.length > 0) {
-      try {
-        mergedOptions.expectedInputs = expectedInputs;
-        console.log('Built-in AI: Attempting to create multimodal session with expected inputs:', expectedInputs);
-        this.session = await LanguageModel.create(mergedOptions);
-        console.log('Built-in AI: Multimodal session created successfully');
-        return this.session;
-      } catch (error) {
-        console.warn('Built-in AI: Multimodal session creation failed, falling back to text-only:', error);
-        // Fall back to text-only session
-        const textOnlyOptions = { ...mergedOptions };
-        delete textOnlyOptions.expectedInputs;
-        this.session = await LanguageModel.create(textOnlyOptions);
-        console.log('Built-in AI: Text-only fallback session created');
-        return this.session;
-      }
+    // Add system message to initialPrompts if provided
+    if (systemMessage) {
+      mergedOptions.initialPrompts = [{ role: "system", content: systemMessage }];
     }
 
-    console.log('Built-in AI: Creating text-only session with options:', mergedOptions);
+    // Add expected inputs if provided
+    if (expectedInputs && expectedInputs.length > 0) {
+      mergedOptions.expectedInputs = expectedInputs;
+    }
+
     this.session = await LanguageModel.create(mergedOptions);
-    console.log('Built-in AI: Session created successfully');
 
     return this.session;
   }
@@ -182,7 +171,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "tools",
-        details: "Tool calling is not yet supported by browser AI",
+        details: "Tool calling is not yet supported by Prompt API",
       });
     }
 
@@ -190,7 +179,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "maxOutputTokens",
-        details: "maxOutputTokens is not supported by browser AI",
+        details: "maxOutputTokens is not supported by Prompt API",
       });
     }
 
@@ -198,7 +187,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "stopSequences",
-        details: "stopSequences is not supported by browser AI",
+        details: "stopSequences is not supported by Prompt API",
       });
     }
 
@@ -206,7 +195,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "topP",
-        details: "topP is not supported by browser AI",
+        details: "topP is not supported by Prompt API",
       });
     }
 
@@ -214,7 +203,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "presencePenalty",
-        details: "presencePenalty is not supported by browser AI",
+        details: "presencePenalty is not supported by Prompt API",
       });
     }
 
@@ -222,7 +211,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "frequencyPenalty",
-        details: "frequencyPenalty is not supported by browser AI",
+        details: "frequencyPenalty is not supported by Prompt API",
       });
     }
 
@@ -230,20 +219,17 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
       warnings.push({
         type: "unsupported-setting",
         setting: "seed",
-        details: "seed is not supported by browser AI",
+        details: "seed is not supported by Prompt API",
       });
     }
 
     // Check if this is a multimodal prompt
-    const isMultimodal = hasMultimodalContent(prompt);
-    console.log('Built-in AI: isMultimodal:', isMultimodal);
+    const hasMultiModalInput = hasMultimodalContent(prompt);
 
-    // Convert messages to the appropriate format
-    const messages = isMultimodal
-      ? convertToBuiltInAIMessages(prompt)
-      : convertToLegacyStringFormat(prompt);
+    // Convert messages to the DOM API format
+    const { systemMessage, messages } = convertToBuiltInAIMessages(prompt);
 
-    // Handle response format for browser AI
+    // Handle response format for Prompt API
     const promptOptions: any = {};
     if (responseFormat?.type === "json") {
       promptOptions.responseConstraint = responseFormat.schema;
@@ -259,11 +245,12 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
     }
 
     return {
+      systemMessage,
       messages,
       warnings,
       promptOptions,
-      isMultimodal,
-      expectedInputs: isMultimodal ? getExpectedInputs(prompt) : undefined
+      hasMultiModalInput,
+      expectedInputs: hasMultiModalInput ? getExpectedInputs(prompt) : undefined
     };
   }
 
@@ -271,25 +258,14 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
    * Generates a complete text response using the browser's built-in Prompt API
    * @param options
    * @returns Promise resolving to the generated content with finish reason, usage stats, and any warnings
-   * @throws {LoadSettingError} When browser AI is not available or model needs to be downloaded
+   * @throws {LoadSettingError} When the Prompt API is not available or model needs to be downloaded
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doGenerate(options: LanguageModelV2CallOptions) {
-    const { messages, warnings, promptOptions, expectedInputs, isMultimodal } = await this.getArgs(options);
+    const converted = this.getArgs(options);
+    const { systemMessage, messages, warnings, promptOptions, expectedInputs } = converted;
 
-    console.log('Built-in AI: messages to send:', messages);
-    console.log('Built-in AI: expected inputs:', expectedInputs);
-    console.log('Built-in AI: prompt options:', promptOptions);
-
-    const session = await this.getSession(undefined, expectedInputs);
-
-    // If we detected multimodal content but couldn't create a multimodal session,
-    // we need to check if the session supports multimodal input
-    if (isMultimodal && (!expectedInputs || expectedInputs.length === 0)) {
-      throw new UnsupportedFunctionalityError({
-        functionality: "Multimodal input (images/audio) - this browser/device doesn't support multimodal AI sessions",
-      });
-    }
+    const session = await this.getSession(undefined, expectedInputs, systemMessage);
 
     const text = await session.prompt(messages, promptOptions);
 
@@ -317,21 +293,14 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
    * Generates a streaming text response using the browser's built-in Prompt API
    * @param options
    * @returns Promise resolving to a readable stream of text chunks and request metadata
-   * @throws {LoadSettingError} When browser AI is not available or model needs to be downloaded
+   * @throws {LoadSettingError} When the Prompt API is not available or model needs to be downloaded
    * @throws {UnsupportedFunctionalityError} When unsupported features like file input are used
    */
   public async doStream(options: LanguageModelV2CallOptions) {
-    const { messages, warnings, promptOptions, expectedInputs, isMultimodal } = await this.getArgs(options);
+    const converted = this.getArgs(options);
+    const { systemMessage, messages, warnings, promptOptions, expectedInputs, hasMultiModalInput } = converted;
 
-    const session = await this.getSession(undefined, expectedInputs);
-
-    // If we detected multimodal content but couldn't create a multimodal session,
-    // we need to check if the session supports multimodal input
-    if (isMultimodal && (!expectedInputs || expectedInputs.length === 0)) {
-      throw new UnsupportedFunctionalityError({
-        functionality: "Multimodal input (images/audio) - this browser/device doesn't support multimodal AI sessions",
-      });
-    }
+    const session = await this.getSession(undefined, expectedInputs, systemMessage);
 
     // Pass abort signal to the native streaming method
     const streamOptions = {
@@ -391,7 +360,7 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
             type: "finish",
             finishReason: "stop" as LanguageModelV2FinishReason,
             usage: {
-              inputTokens: undefined,
+              inputTokens: session.inputUsage,
               outputTokens: undefined,
               totalTokens: undefined,
             },
@@ -407,41 +376,4 @@ export class BuiltInAIChatLanguageModel implements LanguageModelV2 {
   }
 }
 
-// Legacy function for backward compatibility - only used for text-only prompts
-function convertToLegacyStringFormat(prompt: LanguageModelV2Prompt): string {
-  let result = "";
 
-  for (const message of prompt) {
-    switch (message.role) {
-      case "system":
-        result += `${message.content}\n`;
-        break;
-      case "assistant":
-        for (const part of message.content) {
-          if (part.type === "text") {
-            result += `model\n${part.text}\n`;
-          } else if (part.type === "tool-call") {
-            // TODO: Implement
-          }
-        }
-        break;
-      case "user":
-        for (const part of message.content) {
-          if (part.type === "text") {
-            result += `user\n${part.text}\n`;
-          } else if (part.type === "file") {
-            throw new UnsupportedFunctionalityError({
-              functionality: "file input",
-            });
-          }
-        }
-        break;
-      case "tool":
-        // TODO: Implement
-        break;
-    }
-  }
-
-  result += `model\n`;
-  return result;
-}

--- a/packages/built-in-ai/src/convert-to-built-in-ai-messages.ts
+++ b/packages/built-in-ai/src/convert-to-built-in-ai-messages.ts
@@ -1,0 +1,97 @@
+import {
+  LanguageModelV2Prompt,
+  UnsupportedFunctionalityError,
+} from "@ai-sdk/provider";
+
+/**
+ * Convert Vercel AI SDK prompt format to built-in AI Prompt API format
+ */
+export function convertToBuiltInAIMessages(prompt: LanguageModelV2Prompt): any[] {
+  const messages = [];
+
+  for (const message of prompt) {
+    switch (message.role) {
+      case "system": {
+        messages.push({
+          role: "system",
+          content: message.content
+        });
+        break;
+      }
+
+      case "user": {
+        messages.push({
+          role: "user",
+          content: message.content.map(part => {
+            switch (part.type) {
+              case "text": {
+                return { type: "text", value: part.text };
+              }
+
+              case "file": {
+                if (part.mediaType?.startsWith("image/")) {
+                  return {
+                    type: "image",
+                    value: part.data instanceof URL ? part.data.toString() : part.data,
+                  };
+                } else if (part.mediaType?.startsWith("audio/")) {
+                  return {
+                    type: "audio",
+                    value: part.data instanceof URL ? part.data.toString() : part.data,
+                  };
+                } else {
+                  throw new UnsupportedFunctionalityError({
+                    functionality: `file type: ${part.mediaType}`,
+                  });
+                }
+              }
+
+              default: {
+                throw new UnsupportedFunctionalityError({
+                  functionality: `content type: ${(part as any).type}`,
+                });
+              }
+            }
+          }),
+        });
+        break;
+      }
+
+      case "assistant": {
+        let text = "";
+
+        for (const part of message.content) {
+          switch (part.type) {
+            case "text": {
+              text += part.text;
+              break;
+            }
+            case "tool-call": {
+              throw new UnsupportedFunctionalityError({
+                functionality: "tool calls",
+              });
+            }
+          }
+        }
+
+        messages.push({
+          role: "assistant",
+          content: text,
+        });
+        break;
+      }
+
+      case "tool": {
+        throw new UnsupportedFunctionalityError({
+          functionality: "tool messages",
+        });
+      }
+
+      default: {
+        throw new Error(`Unsupported role: ${(message as any).role}`);
+      }
+    }
+  }
+
+  return messages;
+}

--- a/packages/built-in-ai/src/convert-to-built-in-ai-messages.ts
+++ b/packages/built-in-ai/src/convert-to-built-in-ai-messages.ts
@@ -41,7 +41,7 @@ function convertFileData(data: any, mediaType: string): Uint8Array | string {
     return data;
   }
 
-  if (typeof data === 'string') {
+  if (typeof data === "string") {
     // Base64 string from AI SDK - convert to Uint8Array
     return convertBase64ToUint8Array(data);
   }
@@ -55,7 +55,9 @@ function convertFileData(data: any, mediaType: string): Uint8Array | string {
  * Convert Vercel AI SDK prompt format to built-in AI Prompt API format
  * Returns system message (for initialPrompts) and regular messages (for prompt method)
  */
-export function convertToBuiltInAIMessages(prompt: LanguageModelV2Prompt): ConvertedMessages {
+export function convertToBuiltInAIMessages(
+  prompt: LanguageModelV2Prompt,
+): ConvertedMessages {
   let systemMessage: string | undefined;
   const messages: LanguageModelMessage[] = [];
 
@@ -70,10 +72,13 @@ export function convertToBuiltInAIMessages(prompt: LanguageModelV2Prompt): Conve
       case "user": {
         messages.push({
           role: "user",
-          content: message.content.map(part => {
+          content: message.content.map((part) => {
             switch (part.type) {
               case "text": {
-                return { type: "text", value: part.text } as LanguageModelMessageContent;
+                return {
+                  type: "text",
+                  value: part.text,
+                } as LanguageModelMessageContent;
               }
 
               case "file": {
@@ -86,7 +91,6 @@ export function convertToBuiltInAIMessages(prompt: LanguageModelV2Prompt): Conve
                     type: "image",
                     value: convertedData,
                   } as LanguageModelMessageContent;
-
                 } else if (mediaType?.startsWith("audio/")) {
                   const convertedData = convertFileData(data, mediaType);
 
@@ -94,7 +98,6 @@ export function convertToBuiltInAIMessages(prompt: LanguageModelV2Prompt): Conve
                     type: "audio",
                     value: convertedData,
                   } as LanguageModelMessageContent;
-
                 } else {
                   throw new UnsupportedFunctionalityError({
                     functionality: `file type: ${mediaType}`,

--- a/packages/built-in-ai/test/built-in-ai-language-model.test.ts
+++ b/packages/built-in-ai/test/built-in-ai-language-model.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { BuiltInAIChatLanguageModel, BuiltInAIChatSettings } from "../src/built-in-ai-language-model";
+import {
+  BuiltInAIChatLanguageModel,
+  BuiltInAIChatSettings,
+} from "../src/built-in-ai-language-model";
 
 import { generateText, streamText, generateObject, streamObject } from "ai";
 import { LoadSettingError } from "@ai-sdk/provider";
@@ -74,10 +77,15 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(result.text).toBe("Hello, world!");
-    expect(mockPrompt).toHaveBeenCalledWith([{
-      role: "user",
-      content: [{ type: "text", value: "Say hello" }],
-    }], {});
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "Say hello" }],
+        },
+      ],
+      {},
+    );
   });
 
   it("should handle system messages", async () => {
@@ -92,10 +100,15 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(result.text).toBe("I am a helpful assistant.");
-    expect(mockPrompt).toHaveBeenCalledWith([{
-      role: "user",
-      content: [{ type: "text", value: "Who are you?" }],
-    }], {});
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "Who are you?" }],
+        },
+      ],
+      {},
+    );
   });
 
   it("should handle conversation history", async () => {
@@ -111,20 +124,23 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(result.text).toBe("I can help you with that!");
-    expect(mockPrompt).toHaveBeenCalledWith([
-      {
-        role: "user",
-        content: [{ type: "text", value: "Can you help me?" }],
-      },
-      {
-        role: "assistant",
-        content: "Of course! What do you need?",
-      },
-      {
-        role: "user",
-        content: [{ type: "text", value: "I need assistance with coding." }],
-      },
-    ], {});
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "Can you help me?" }],
+        },
+        {
+          role: "assistant",
+          content: "Of course! What do you need?",
+        },
+        {
+          role: "user",
+          content: [{ type: "text", value: "I need assistance with coding." }],
+        },
+      ],
+      {},
+    );
   });
 
   it("should stream text successfully", async () => {
@@ -150,12 +166,17 @@ describe("BuiltInAIChatLanguageModel", () => {
     }
 
     expect(text).toBe("Hello, world!");
-    expect(mockPromptStreaming).toHaveBeenCalledWith([{
-      role: "user",
-      content: [{ type: "text", value: "Say hello" }],
-    }], {
-      signal: undefined,
-    });
+    expect(mockPromptStreaming).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "Say hello" }],
+        },
+      ],
+      {
+        signal: undefined,
+      },
+    );
   });
 
   it("should handle JSON response format", async () => {
@@ -174,21 +195,26 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(object).toEqual({ name: "John", age: 30 });
-    expect(mockPrompt).toHaveBeenCalledWith([{
-      role: "user",
-      content: [{ type: "text", value: "Create a person" }],
-    }], {
-      responseConstraint: {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        additionalProperties: false,
-        properties: {
-          age: { type: "number" },
-          name: { type: "string" },
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "Create a person" }],
         },
-        required: ["name", "age"],
-        type: "object",
+      ],
+      {
+        responseConstraint: {
+          $schema: "http://json-schema.org/draft-07/schema#",
+          additionalProperties: false,
+          properties: {
+            age: { type: "number" },
+            name: { type: "string" },
+          },
+          required: ["name", "age"],
+          type: "object",
+        },
       },
-    });
+    );
   });
 
   it("should handle object generation mode", async () => {
@@ -206,23 +232,28 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(object).toEqual({ users: ["Alice", "Bob"] });
-    expect(mockPrompt).toHaveBeenCalledWith([{
-      role: "user",
-      content: [{ type: "text", value: "List some users" }],
-    }], {
-      responseConstraint: {
-        $schema: "http://json-schema.org/draft-07/schema#",
-        additionalProperties: false,
-        properties: {
-          users: {
-            items: { type: "string" },
-            type: "array",
-          },
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [{ type: "text", value: "List some users" }],
         },
-        required: ["users"],
-        type: "object",
+      ],
+      {
+        responseConstraint: {
+          $schema: "http://json-schema.org/draft-07/schema#",
+          additionalProperties: false,
+          properties: {
+            users: {
+              items: { type: "string" },
+              type: "array",
+            },
+          },
+          required: ["users"],
+          type: "object",
+        },
       },
-    });
+    );
   });
 
   it("should handle complex JSON schemas", async () => {
@@ -276,16 +307,23 @@ describe("BuiltInAIChatLanguageModel", () => {
     });
 
     expect(result.text).toBe("Response");
-    expect(mockPrompt).toHaveBeenCalledWith([{
-      role: "user",
-      content: [],
-    }], {});
+    expect(mockPrompt).toHaveBeenCalledWith(
+      [
+        {
+          role: "user",
+          content: [],
+        },
+      ],
+      {},
+    );
   });
 
   describe("multimodal support", () => {
     beforeEach(() => {
       // Mock LanguageModel.create to capture the options passed to it
-      (global as any).LanguageModel.create = vi.fn().mockResolvedValue(mockSession);
+      (global as any).LanguageModel.create = vi
+        .fn()
+        .mockResolvedValue(mockSession);
     });
 
     it("should handle image files in messages", async () => {
@@ -314,7 +352,7 @@ describe("BuiltInAIChatLanguageModel", () => {
       expect((global as any).LanguageModel.create).toHaveBeenCalledWith(
         expect.objectContaining<Partial<BuiltInAIChatSettings>>({
           expectedInputs: [{ type: "image" }],
-        })
+        }),
       );
     });
 
@@ -344,7 +382,7 @@ describe("BuiltInAIChatLanguageModel", () => {
       expect((global as any).LanguageModel.create).toHaveBeenCalledWith(
         expect.objectContaining<Partial<BuiltInAIChatSettings>>({
           expectedInputs: [{ type: "audio" }],
-        })
+        }),
       );
     });
 
@@ -383,7 +421,7 @@ describe("BuiltInAIChatLanguageModel", () => {
             { type: "image" },
             { type: "audio" },
           ]),
-        })
+        }),
       );
     });
 
@@ -412,7 +450,7 @@ describe("BuiltInAIChatLanguageModel", () => {
       expect((global as any).LanguageModel.create).toHaveBeenCalledWith(
         expect.objectContaining<Partial<BuiltInAIChatSettings>>({
           expectedInputs: [{ type: "image" }],
-        })
+        }),
       );
     });
   });

--- a/packages/built-in-ai/test/convert-to-built-in-ai-messages.test.ts
+++ b/packages/built-in-ai/test/convert-to-built-in-ai-messages.test.ts
@@ -3,7 +3,7 @@ import { convertToBuiltInAIMessages } from "../src/convert-to-built-in-ai-messag
 import {
   LanguageModelV2Prompt,
   LanguageModelV2Message,
-  UnsupportedFunctionalityError
+  UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 
 describe("convertToBuiltInAIMessages", () => {
@@ -108,7 +108,9 @@ describe("convertToBuiltInAIMessages", () => {
       expect(imageContent.value).toBeInstanceOf(Uint8Array);
 
       // Verify the conversion worked correctly
-      const expectedBytes = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+      const expectedBytes = new Uint8Array([
+        72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100,
+      ]);
       expect(imageContent.value).toEqual(expectedBytes);
     });
 
@@ -268,7 +270,7 @@ describe("convertToBuiltInAIMessages", () => {
       ];
 
       expect(() => convertToBuiltInAIMessages(prompt)).toThrow(
-        UnsupportedFunctionalityError
+        UnsupportedFunctionalityError,
       );
     });
 
@@ -286,7 +288,7 @@ describe("convertToBuiltInAIMessages", () => {
       ] as LanguageModelV2Prompt;
 
       expect(() => convertToBuiltInAIMessages(prompt)).toThrow(
-        UnsupportedFunctionalityError
+        UnsupportedFunctionalityError,
       );
     });
 
@@ -334,4 +336,4 @@ describe("convertToBuiltInAIMessages", () => {
       ]);
     });
   });
-}); 
+});

--- a/packages/built-in-ai/test/convert-to-built-in-ai-messages.test.ts
+++ b/packages/built-in-ai/test/convert-to-built-in-ai-messages.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "vitest";
+import { convertToBuiltInAIMessages } from "../src/convert-to-built-in-ai-messages";
+import {
+  LanguageModelV2Prompt,
+  LanguageModelV2Message,
+  UnsupportedFunctionalityError
+} from "@ai-sdk/provider";
+
+describe("convertToBuiltInAIMessages", () => {
+  describe("text messages", () => {
+    it("should convert simple text user message", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello, world!" }],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.systemMessage).toBeUndefined();
+      expect(result.messages).toEqual([
+        {
+          role: "user",
+          content: [{ type: "text", value: "Hello, world!" }],
+        },
+      ]);
+    });
+
+    it("should extract system message", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "system",
+          content: "You are a helpful assistant.",
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello!" }],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.systemMessage).toBe("You are a helpful assistant.");
+      expect(result.messages).toEqual([
+        {
+          role: "user",
+          content: [{ type: "text", value: "Hello!" }],
+        },
+      ]);
+    });
+
+    it("should convert assistant messages", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello!" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi there!" }],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages).toEqual([
+        {
+          role: "user",
+          content: [{ type: "text", value: "Hello!" }],
+        },
+        {
+          role: "assistant",
+          content: "Hi there!",
+        },
+      ]);
+    });
+  });
+
+  describe("image file conversion", () => {
+    it("should convert base64 image data to Uint8Array", () => {
+      const base64Data = "SGVsbG8gV29ybGQ="; // "Hello World" in base64
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What's in this image?" },
+            {
+              type: "file",
+              mediaType: "image/png",
+              data: base64Data,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toHaveLength(2);
+      expect(result.messages[0].content[0]).toEqual({
+        type: "text",
+        value: "What's in this image?",
+      });
+
+      const imageContent = result.messages[0].content[1] as any;
+      expect(imageContent.type).toBe("image");
+      expect(imageContent.value).toBeInstanceOf(Uint8Array);
+
+      // Verify the conversion worked correctly
+      const expectedBytes = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+      expect(imageContent.value).toEqual(expectedBytes);
+    });
+
+    it("should handle Uint8Array image data directly", () => {
+      const uint8Data = new Uint8Array([1, 2, 3, 4]);
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "image/jpeg",
+              data: uint8Data,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages[0].content[0]).toEqual({
+        type: "image",
+        value: uint8Data,
+      });
+    });
+
+    it("should handle URL image data", () => {
+      const imageUrl = new URL("https://example.com/image.png");
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "image/webp",
+              data: imageUrl,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages[0].content[0]).toEqual({
+        type: "image",
+        value: "https://example.com/image.png",
+      });
+    });
+  });
+
+  describe("audio file conversion", () => {
+    it("should convert base64 audio data to Uint8Array", () => {
+      const base64Data = "UklGRnQAAABXQVZF"; // Valid WAV header start in base64
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What's in this audio?" },
+            {
+              type: "file",
+              mediaType: "audio/wav",
+              data: base64Data,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages[0].content[1]).toEqual({
+        type: "audio",
+        value: expect.any(Uint8Array),
+      });
+    });
+
+    it("should handle Uint8Array audio data directly", () => {
+      const audioData = new Uint8Array([82, 73, 70, 70]); // "RIFF" header
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "audio/mp3",
+              data: audioData,
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages[0].content[0]).toEqual({
+        type: "audio",
+        value: audioData,
+      });
+    });
+  });
+
+  describe("mixed content", () => {
+    it("should handle mixed text, image, and audio content", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Analyze this:" },
+            {
+              type: "file",
+              mediaType: "image/png",
+              data: "SGVsbG8=", // "Hello" in base64
+            },
+            { type: "text", text: "And this audio:" },
+            {
+              type: "file",
+              mediaType: "audio/wav",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages[0].content).toHaveLength(4);
+      expect(result.messages[0].content[0]).toEqual({
+        type: "text",
+        value: "Analyze this:",
+      });
+      expect(result.messages[0].content[1]).toEqual({
+        type: "image",
+        value: expect.any(Uint8Array),
+      });
+      expect(result.messages[0].content[2]).toEqual({
+        type: "text",
+        value: "And this audio:",
+      });
+      expect(result.messages[0].content[3]).toEqual({
+        type: "audio",
+        value: new Uint8Array([1, 2, 3]),
+      });
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw for unsupported file types", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "video/mp4",
+              data: "some data",
+            },
+          ],
+        },
+      ];
+
+      expect(() => convertToBuiltInAIMessages(prompt)).toThrow(
+        UnsupportedFunctionalityError
+      );
+    });
+
+    it("should throw for unsupported content types", () => {
+      const prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "unsupported" as any,
+              data: "some data",
+            },
+          ],
+        },
+      ] as LanguageModelV2Prompt;
+
+      expect(() => convertToBuiltInAIMessages(prompt)).toThrow(
+        UnsupportedFunctionalityError
+      );
+    });
+
+    it("should throw for invalid base64 data", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              mediaType: "image/png",
+              data: "invalid-base64-data!@#",
+            },
+          ],
+        },
+      ];
+
+      expect(() => convertToBuiltInAIMessages(prompt)).toThrow();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty prompt", () => {
+      const result = convertToBuiltInAIMessages([]);
+
+      expect(result.systemMessage).toBeUndefined();
+      expect(result.messages).toEqual([]);
+    });
+
+    it("should handle empty content arrays", () => {
+      const prompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [],
+        },
+      ];
+
+      const result = convertToBuiltInAIMessages(prompt);
+
+      expect(result.messages).toEqual([
+        {
+          role: "user",
+          content: [],
+        },
+      ]);
+    });
+  });
+}); 


### PR DESCRIPTION
This PR adds multimodal support to the model provider. 
Currently only implemented in Chrome, so it won't work in Edge yet but API reference is the same.

## Usage

```tsx:useChat() multimodal example
import { streamText } from "ai";
import { builtInAI } from "@built-in-ai/core";

const result = streamText({
  model: builtInAI(),
  messages: [
    {
      role: "user",
      content: [{ type: "file", mediaType: "audio/mp3", data: audioData }],
    },
    {
      role: "user",
      content: [
        { type: "text", text: "What's in this image?" },
        { type: "file", mediaType: "image/png", data: base64Data },
      ],
    },
  ],
});

for await (const chunk of result.textStream) {
  console.log(chunk);
}
```

Make sure to enable the new flag "Prompt API for Gemini Nano with Multimodal Input" in Chrome to use it. I've updated the readme accordingly to include this.