### PR TITLE
BREAKING CHANGE(built-in-ai): adhere to ProviderV2

### DIFF
--- a/.changeset/tame-rocks-chew.md
+++ b/.changeset/tame-rocks-chew.md
@@ -1,0 +1,5 @@
+---
+"@built-in-ai/web-llm": patch
+---
+
+docs: update readme

--- a/.changeset/twenty-ghosts-taste.md
+++ b/.changeset/twenty-ghosts-taste.md
@@ -1,0 +1,5 @@
+---
+"@built-in-ai/core": major
+---
+
+BREAKING CHANGE: adhere to ProviderV2

--- a/package-lock.json
+++ b/package-lock.json
@@ -14447,7 +14447,7 @@
     },
     "packages/transformers-js": {
       "name": "@built-in-ai/transformers-js",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.7.1"

--- a/packages/built-in-ai/README.md
+++ b/packages/built-in-ai/README.md
@@ -7,7 +7,7 @@
 <div align="center">
 
 [![NPM Version](https://img.shields.io/npm/v/%40built-in-ai%2Fcore)](https://www.npmjs.com/package/@built-in-ai/core)
-[![NPM Downloads](https://img.shields.io/npm/dw/%40built-in-ai%2Fcore)](https://www.npmjs.com/package/@built-in-ai/core)
+[![NPM Downloads](https://img.shields.io/npm/dm/%40built-in-ai%2Fcore)](https://www.npmjs.com/package/@built-in-ai/core)
 
 </div>
 
@@ -22,7 +22,7 @@ A TypeScript library that provides access to browser-based AI capabilities with 
 npm i @built-in-ai/core
 ```
 
-The `@built-in-ai/core` package is the AI SDK provider for your Chrome and Edge browser's built-in AI models.
+The `@built-in-ai/core` package is the AI SDK provider for your Chrome and Edge browser's built-in AI models. It provides seamless access to both language models and text embeddings through browser-native APIs.
 
 ## Browser Requirements
 
@@ -40,17 +40,16 @@ The `@built-in-ai/core` package is the AI SDK provider for your Chrome and Edge 
 
 For more information, check out [this guide](https://developer.chrome.com/docs/extensions/ai/prompt-api)
 
-## Basic Usage
+## Usage
 
-### Simple Chat
+### Basic Usage (chat)
 
 ```typescript
 import { streamText } from "ai";
 import { builtInAI } from "@built-in-ai/core";
 
-const result = streamText({
-  // or generateText
-  model: builtInAI(),
+const result = streamText({ // or generateText
+  model: builtInAI(), 
   messages: [{ role: "user", content: "Hello, how are you?" }],
 });
 
@@ -59,18 +58,41 @@ for await (const chunk of result.textStream) {
 }
 ```
 
+### Language Models
+
+```typescript
+import { generateText } from "ai";
+import { builtInAI } from "@built-in-ai/core";
+
+const model = builtInAI();
+
+const result = await generateText({
+  model,
+  messages: [{ role: "user", content: "Write a short poem about AI" }],
+});
+```
+
 ### Text Embeddings
 
 ```typescript
-import { embed } from "ai";
+import { embed, embedMany } from "ai";
 import { builtInAI } from "@built-in-ai/core";
 
+// Single embedding
 const result = await embed({
-  model: builtInAI("embedding"),
+  model: builtInAI.textEmbedding("embedding"),
   value: "Hello, world!",
 });
 
 console.log(result.embedding); // [0.1, 0.2, 0.3, ...]
+
+// Multiple embeddings
+const results = await embedMany({
+  model: builtInAI.textEmbedding("embedding"),
+  values: ["Hello", "World", "AI"],
+});
+
+console.log(results.embeddings); // [[...], [...], [...]]
 ```
 
 ## Download Progress Tracking

--- a/packages/built-in-ai/README.md
+++ b/packages/built-in-ai/README.md
@@ -48,8 +48,9 @@ For more information, check out [this guide](https://developer.chrome.com/docs/e
 import { streamText } from "ai";
 import { builtInAI } from "@built-in-ai/core";
 
-const result = streamText({ // or generateText
-  model: builtInAI(), 
+const result = streamText({
+  // or generateText
+  model: builtInAI(),
   messages: [{ role: "user", content: "Hello, how are you?" }],
 });
 

--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -11,7 +11,8 @@ export { BuiltInAIEmbeddingModel } from "./built-in-ai-embedding-model";
 export type { BuiltInAIEmbeddingModelSettings } from "./built-in-ai-embedding-model";
 
 // Provider
-export { builtInAI } from "./built-in-ai-provider";
+export { builtInAI, createBuiltInAI } from "./built-in-ai-provider";
+export type { BuiltInAIProvider, BuiltInAIProviderSettings } from "./built-in-ai-provider";
 
 // UI types
 export type { BuiltInAIUIMessage } from "./ui-message-types";

--- a/packages/built-in-ai/src/index.ts
+++ b/packages/built-in-ai/src/index.ts
@@ -12,7 +12,10 @@ export type { BuiltInAIEmbeddingModelSettings } from "./built-in-ai-embedding-mo
 
 // Provider
 export { builtInAI, createBuiltInAI } from "./built-in-ai-provider";
-export type { BuiltInAIProvider, BuiltInAIProviderSettings } from "./built-in-ai-provider";
+export type {
+  BuiltInAIProvider,
+  BuiltInAIProviderSettings,
+} from "./built-in-ai-provider";
 
 // UI types
 export type { BuiltInAIUIMessage } from "./ui-message-types";

--- a/packages/built-in-ai/test/built-in-ai-provider.test.ts
+++ b/packages/built-in-ai/test/built-in-ai-provider.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { builtInAI, createBuiltInAI } from "../src/built-in-ai-provider";
+import { BuiltInAIChatLanguageModel } from "../src/built-in-ai-language-model";
+import { BuiltInAIEmbeddingModel } from "../src/built-in-ai-embedding-model";
+
+// Mock the dependencies
+vi.mock("../src/built-in-ai-language-model", () => ({
+  BuiltInAIChatLanguageModel: vi.fn(),
+}));
+
+vi.mock("../src/built-in-ai-embedding-model", () => ({
+  BuiltInAIEmbeddingModel: vi.fn(),
+}));
+
+describe("BuiltInAI Provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createBuiltInAI", () => {
+    it("should create a provider with all expected methods", () => {
+      const provider = createBuiltInAI();
+
+      expect(provider).toBeInstanceOf(Function);
+      expect(provider.languageModel).toBeInstanceOf(Function);
+      expect(provider.chat).toBeInstanceOf(Function);
+      expect(provider.textEmbedding).toBeInstanceOf(Function);
+      expect(provider.textEmbeddingModel).toBeInstanceOf(Function);
+      expect(provider.imageModel).toBeInstanceOf(Function);
+      expect(provider.speechModel).toBeInstanceOf(Function);
+      expect(provider.transcriptionModel).toBeInstanceOf(Function);
+    });
+
+    it("should prevent calling with new keyword", () => {
+      const provider = createBuiltInAI();
+
+      expect(() => {
+        // @ts-expect-error - intentionally testing invalid usage
+        new provider("text");
+      }).toThrow("The BuiltInAI model function cannot be called with the new keyword.");
+    });
+  });
+
+  describe("Language Model Creation", () => {
+    it("should create language model via direct call with explicit model ID", () => {
+      const provider = createBuiltInAI();
+      provider("text", { temperature: 0.5 });
+
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.5 });
+    });
+
+    it("should create language model via direct call with default model ID", () => {
+      const provider = createBuiltInAI();
+      provider(undefined, { temperature: 0.5 });
+
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.5 });
+    });
+
+    it("should create language model via direct call with no parameters", () => {
+      const provider = createBuiltInAI();
+      provider();
+
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", undefined);
+    });
+
+    it("should create language model via languageModel method", () => {
+      const provider = createBuiltInAI();
+      provider.languageModel("text", { temperature: 0.7 });
+
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.7 });
+    });
+
+    it("should create language model via chat method", () => {
+      const provider = createBuiltInAI();
+      provider.chat("text", { temperature: 0.9 });
+
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.9 });
+    });
+  });
+
+  describe("Embedding Model Creation", () => {
+    it("should create embedding model via textEmbedding method", () => {
+      const provider = createBuiltInAI();
+      const settings = { l2Normalize: true };
+      provider.textEmbedding("embedding", settings);
+
+      expect(BuiltInAIEmbeddingModel).toHaveBeenCalledWith(settings);
+    });
+
+    it("should create embedding model via textEmbeddingModel method", () => {
+      const provider = createBuiltInAI();
+      const settings = { quantize: true };
+      provider.textEmbeddingModel("embedding", settings);
+
+      expect(BuiltInAIEmbeddingModel).toHaveBeenCalledWith(settings);
+    });
+  });
+
+  describe("Unsupported Model Types", () => {
+    it("should throw NoSuchModelError for image models", () => {
+      const provider = createBuiltInAI();
+
+      expect(() => provider.imageModel("image")).toThrow();
+    });
+
+    it("should throw NoSuchModelError for speech models", () => {
+      const provider = createBuiltInAI();
+
+      expect(() => provider.speechModel("speech")).toThrow();
+    });
+
+    it("should throw NoSuchModelError for transcription models", () => {
+      const provider = createBuiltInAI();
+
+      expect(() => provider.transcriptionModel("transcribe")).toThrow();
+    });
+  });
+
+  describe("Default Provider Instance", () => {
+    it("should export a default provider instance", () => {
+      expect(builtInAI).toBeInstanceOf(Function);
+      expect(builtInAI.textEmbedding).toBeInstanceOf(Function);
+      expect(builtInAI.chat).toBeInstanceOf(Function);
+    });
+
+    it("should work with the new API pattern", () => {
+      // Test the new API pattern the user wanted
+      builtInAI.textEmbedding("embedding", { l2Normalize: true });
+
+      expect(BuiltInAIEmbeddingModel).toHaveBeenCalledWith({ l2Normalize: true });
+    });
+  });
+});

--- a/packages/built-in-ai/test/built-in-ai-provider.test.ts
+++ b/packages/built-in-ai/test/built-in-ai-provider.test.ts
@@ -37,7 +37,9 @@ describe("BuiltInAI Provider", () => {
       expect(() => {
         // @ts-expect-error - intentionally testing invalid usage
         new provider("text");
-      }).toThrow("The BuiltInAI model function cannot be called with the new keyword.");
+      }).toThrow(
+        "The BuiltInAI model function cannot be called with the new keyword.",
+      );
     });
   });
 
@@ -46,35 +48,46 @@ describe("BuiltInAI Provider", () => {
       const provider = createBuiltInAI();
       provider("text", { temperature: 0.5 });
 
-      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.5 });
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", {
+        temperature: 0.5,
+      });
     });
 
     it("should create language model via direct call with default model ID", () => {
       const provider = createBuiltInAI();
       provider(undefined, { temperature: 0.5 });
 
-      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.5 });
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", {
+        temperature: 0.5,
+      });
     });
 
     it("should create language model via direct call with no parameters", () => {
       const provider = createBuiltInAI();
       provider();
 
-      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", undefined);
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith(
+        "text",
+        undefined,
+      );
     });
 
     it("should create language model via languageModel method", () => {
       const provider = createBuiltInAI();
       provider.languageModel("text", { temperature: 0.7 });
 
-      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.7 });
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", {
+        temperature: 0.7,
+      });
     });
 
     it("should create language model via chat method", () => {
       const provider = createBuiltInAI();
       provider.chat("text", { temperature: 0.9 });
 
-      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", { temperature: 0.9 });
+      expect(BuiltInAIChatLanguageModel).toHaveBeenCalledWith("text", {
+        temperature: 0.9,
+      });
     });
   });
 
@@ -127,7 +140,9 @@ describe("BuiltInAI Provider", () => {
       // Test the new API pattern the user wanted
       builtInAI.textEmbedding("embedding", { l2Normalize: true });
 
-      expect(BuiltInAIEmbeddingModel).toHaveBeenCalledWith({ l2Normalize: true });
+      expect(BuiltInAIEmbeddingModel).toHaveBeenCalledWith({
+        l2Normalize: true,
+      });
     });
   });
 });

--- a/packages/web-llm/README.md
+++ b/packages/web-llm/README.md
@@ -7,7 +7,7 @@
 <div align="center">
 
 [![NPM Version](https://img.shields.io/npm/v/%40built-in-ai%2Fweb-llm)](https://www.npmjs.com/package/@built-in-ai/web-llm)
-[![NPM Downloads](https://img.shields.io/npm/dw/%40built-in-ai%2Fweb-llm)](https://www.npmjs.com/package/@built-in-ai/web-llm)
+[![NPM Downloads](https://img.shields.io/npm/dm/%40built-in-ai%2Fweb-llm)](https://www.npmjs.com/package/@built-in-ai/web-llm)
 
 > [!NOTE]
 > This library is still in a very early state where updates might come quite frequently.


### PR DESCRIPTION
For the embedding model with built-in-ai package, this means a migration:

```
// Old
const model = builtInAI("embedding");

// New  
const model = builtInAI.textEmbedding("embedding");
```

Language model remains the same